### PR TITLE
Fix: set NODE_ENV to production for both builds

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -3,12 +3,12 @@ import babel from 'rollup-plugin-babel';
 import {terser} from 'rollup-plugin-terser';
 import commonjs from 'rollup-plugin-commonjs';
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isMinify = process.env.BUILD_MODE === 'minify';
 
 export default {
   input: 'src/index.js',
   output: {
-    file: isProduction ? 'dist/js/vue-gallery.min.js' : 'dist/js/vue-gallery.js',
+    file: isMinify ? 'dist/js/vue-gallery.min.js' : 'dist/js/vue-gallery.js',
     format: 'umd',
     name: 'VueGallery',
   },
@@ -21,6 +21,6 @@ export default {
       runtimeHelpers: true,
       externalHelpers: false,
     }),
-    (isProduction && terser())
+    (isMinify && terser())
   ],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "node_modules/.bin/eslint ./",
-    "build": "node_modules/.bin/rollup -c ./build/rollup.config.js && NODE_ENV=production node_modules/.bin/rollup -c ./build/rollup.config.js",
+    "build": "NODE_ENV=production node_modules/.bin/rollup -c ./build/rollup.config.js && NODE_ENV=production BUILD_MODE=minify node_modules/.bin/rollup -c ./build/rollup.config.js",
     "patch": "npm version patch",
     "minor": "npm version minor",
     "major": "npm version major"


### PR DESCRIPTION
I've seen that the NODE_ENV wasn't set to production for the minified build and I want to fix this :)