### PR TITLE
Better default close character

### DIFF
--- a/src/component/gallery.vue
+++ b/src/component/gallery.vue
@@ -14,7 +14,7 @@
       <slot name="next">›</slot>
     </a>
     <a v-if="!carousel" class="close">
-      <slot name="close">X</slot>
+      <slot name="close">×</slot>
     </a>
     <ol v-if="!carousel" class="indicator"></ol>
     <a v-if="carousel" class="play-pause"></a>


### PR DESCRIPTION
The close link was using a standard `X`, which looks quite ugly by default so I suggest we use `×` or `&times;` instead, which is what the default blueimp Gallery uses.