### PR TITLE
Add Nuxt usage to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,26 @@
 
 Recommended: https://unpkg.com/vue-gallery, which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at https://unpkg.com/vue-gallery/
 
-#### NPM
+#### npm
 
 ``` bash
-npm install vue-gallery --save
+npm install vue-gallery
+
 ```
 
-#### Yarn
+### Nuxt
 
-``` bash
-yarn add vue-gallery
+1. Add a new file named `vue-gallery.client.js` to your nuxt plugins folder. It is important that your filename ends in `.client.js` ([more info on this convention](https://nuxtjs.org/guide/plugins/#name-conventional-plugin)).
+1. Copy paste the following content in it:
+```js
+import Vue from 'vue'
+import VueGallery from 'vue-gallery'
+
+Vue.component('gallery', VueGallery)
 ```
-## Development Setup
-
-``` bash
-# install dependencies
-npm install
-
-# build dist files
-npm run build
+1. Add it to your list of plugins in `nuxt.config.js`
+```js
+plugins: ['~plugins/vue-gallery.client.js']
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ npm install vue-gallery
 
 ```
 
+#### Yarn
+
+``` bash
+yarn add vue-gallery
+
+```
+
 ### Nuxt
 
 1. Add a new file named `vue-gallery.client.js` to your nuxt plugins folder. It is important that your filename ends in `.client.js` ([more info on this convention](https://nuxtjs.org/guide/plugins/#name-conventional-plugin)).
@@ -182,6 +189,17 @@ plugins: ['~plugins/vue-gallery.client.js']
 |---------|--------|-------------|
 | [vue-ls](https://github.com/RobinCK/vue-ls)    | ![npm](https://img.shields.io/npm/v/vue-ls.svg)  | Vue plugin for work with local storage, session storage and memory storage from Vue context |
 | [vue-popper](https://github.com/RobinCK/vue-popper)      | ![npm](https://img.shields.io/npm/v/vue-popperjs.svg) | VueJS popover component based on <a href="https://popper.js.org/">popper.js</a> |
+
+
+## Development Setup
+
+``` bash
+# install dependencies
+npm install
+
+# build dist files
+npm run build
+```
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,22 @@ npm install vue-gallery
 ### Nuxt
 
 1. Add a new file named `vue-gallery.client.js` to your nuxt plugins folder. It is important that your filename ends in `.client.js` ([more info on this convention](https://nuxtjs.org/guide/plugins/#name-conventional-plugin)).
-1. Copy paste the following content in it:
+2. Copy paste the following content in it:
 ```js
 import Vue from 'vue'
 import VueGallery from 'vue-gallery'
 
-Vue.component('gallery', VueGallery)
+Vue.component('VGallery', VueGallery)
 ```
-1. Add it to your list of plugins in `nuxt.config.js`
+3. Add it to your list of plugins in `nuxt.config.js`:
 ```js
 plugins: ['~plugins/vue-gallery.client.js']
+```
+4. You can now use the component globally:
+```js
+<v-gallery :images="images"
+           :index="index"
+           @close="index = null" />
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn add vue-gallery
 
 ### Nuxt
 
-1. Add a new file named `vue-gallery.client.js` to your nuxt plugins folder. It is important that your filename ends in `.client.js` ([more info on this convention](https://nuxtjs.org/guide/plugins/#name-conventional-plugin)).
+1. Add a new file named `vue-gallery.client.js` to your nuxt plugins folder. It is important that your filename ends in `.client.js` ([more info on this convention](https://nuxtjs.org/guide/plugins/#name-conventional-plugin), only works from Nuxt v.2.4.0).
 2. Copy paste the following content in it:
 ```js
 import Vue from 'vue'


### PR DESCRIPTION
@RobinCK  Hey! Thanks for this nice wrapper around https://blueimp.github.io/

Could you please finally add instructions about Nuxt? 
@rlam3 openend a pull request (https://github.com/RobinCK/vue-gallery/pull/7), but it seems to have gone forgotten.

Details
- I'm pretty sure that npm install instructions are understood by Yarn users. And the --save flag is no longer necessary.
- In my example, I named the compenent "VGallery" because of https://github.com/RobinCK/vue-gallery/issues/18 

closes #3 